### PR TITLE
Use default HttpRequestHandler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
   "com.mohiva" %% "play-silhouette" % "3.0.0",
-  "org.webjars" %% "webjars-play" % "2.4.0",
+  "org.webjars" %% "webjars-play" % "2.4.0-1",
   "net.codingwell" %% "scala-guice" % "4.0.0",
   "net.ceedubs" %% "ficus" % "1.1.2",
   "com.adrianhurt" %% "play-bootstrap3" % "0.4.4-P24",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -15,6 +15,10 @@ play.i18n.langs=["en"]
 # ~~~~~
 play.http.errorHandler = "utils.ErrorHandler"
 
+# Registers the request handler
+# ~~~~~
+play.http.requestHandler = "play.api.http.DefaultHttpRequestHandler"
+
 # Registers the filters
 # ~~~~~
 play.http.filters = "utils.Filters"


### PR DESCRIPTION
As per the 2.4 migration guide, the default RequestHandler is still invoking
a provider for GlobalSettings, which is now deprecated.

https://www.playframework.com/documentation/2.4.x/Migration24#HttpRequestHandler