### PR TITLE
iheartradio/ficus resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ resolvers := ("Atlassian Releases" at "https://maven.atlassian.com/public/") +: 
 
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 
+resolvers += Resolver.sonatypeRepo("releases")
+
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(


### PR DESCRIPTION
Sonatype OSS Releases repository must be defined in build to get ficus.