### PR TITLE
Update library dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ resolvers := ("Atlassian Releases" at "https://maven.atlassian.com/public/") +: 
 
 resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases"
 
+resolvers += Resolver.sonatypeRepo("releases")
+
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(
@@ -21,7 +23,7 @@ libraryDependencies ++= Seq(
   "org.webjars" %% "webjars-play" % "2.5.0",
   "net.codingwell" %% "scala-guice" % "4.0.1",
   "com.iheart" %% "ficus" % "1.2.0",
-  "com.adrianhurt" %% "play-bootstrap" % "1.0-P25-B3-SNAPSHOT",
+  "com.adrianhurt" %% "play-bootstrap" % "1.0-P25-B3",
   "com.mohiva" %% "play-silhouette-testkit" % "4.0.0-BETA4" % "test",
   specs2 % Test,
   cache,


### PR DESCRIPTION
This commit updates two things in the build definition:

  1.  It updates the Play-Bootstrap library version.

      According to the Play-Bootstrap website, the library version
      should read "1.0-P25-B3" instead of "1.0-P25-B3-SNAPSHOT".  The
      latter version fails to resolve.

  2.  It adds the Sonatype Releases repository to the list of resolvers.

      Ficus 1.2.0 requires this repository to be declared in the list of
      resolvers.