### PR TITLE
Fixed invalid implicit value syntax

### DIFF
--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -21,9 +21,11 @@ import scala.concurrent.Future
 class ApplicationController @Inject() (
   val messagesApi: MessagesApi,
   silhouette: Silhouette[DefaultEnv],
-  socialProviderRegistry: SocialProviderRegistry,
-  implicit val webJarAssets: WebJarAssets)
-  extends Controller with I18nSupport {
+  socialProviderRegistry: SocialProviderRegistry
+)(
+  implicit
+  webJarAssets: WebJarAssets
+) extends Controller with I18nSupport {
 
   /**
    * Handles the index action.

--- a/app/controllers/SignInController.scala
+++ b/app/controllers/SignInController.scala
@@ -43,9 +43,11 @@ class SignInController @Inject() (
   credentialsProvider: CredentialsProvider,
   socialProviderRegistry: SocialProviderRegistry,
   configuration: Configuration,
-  clock: Clock,
-  implicit val webJarAssets: WebJarAssets)
-  extends Controller with I18nSupport {
+  clock: Clock
+)(
+  implicit
+  webJarAssets: WebJarAssets
+) extends Controller with I18nSupport {
 
   /**
    * Views the `Sign In` page.

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -35,9 +35,11 @@ class SignUpController @Inject() (
   userService: UserService,
   authInfoRepository: AuthInfoRepository,
   avatarService: AvatarService,
-  passwordHasher: PasswordHasher,
-  implicit val webJarAssets: WebJarAssets)
-  extends Controller with I18nSupport {
+  passwordHasher: PasswordHasher
+)(
+  implicit
+  webJarAssets: WebJarAssets
+) extends Controller with I18nSupport {
 
   /**
    * Views the `Sign Up` page.

--- a/app/controllers/SocialAuthController.scala
+++ b/app/controllers/SocialAuthController.scala
@@ -29,9 +29,11 @@ class SocialAuthController @Inject() (
   silhouette: Silhouette[DefaultEnv],
   userService: UserService,
   authInfoRepository: AuthInfoRepository,
-  socialProviderRegistry: SocialProviderRegistry,
-  implicit val webJarAssets: WebJarAssets)
-  extends Controller with I18nSupport with Logger {
+  socialProviderRegistry: SocialProviderRegistry
+)(
+  implicit
+  webJarAssets: WebJarAssets
+) extends Controller with I18nSupport with Logger {
 
   /**
    * Authenticates a user against a social provider.


### PR DESCRIPTION
All the controllers feature the same programming error: using implicit in an invalid manner. Although the Scala compiler does not issue an error message, the variables prefaced with 'implicit' are not implicit. I fixed this error everywhere I found it.