### PR TITLE
Password strength indicator doesn't work in Chrome

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -103,7 +103,6 @@ a {
 
 meter {
     /* Reset the default appearance */
-    -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
 


### PR DESCRIPTION
Fixes #87