### PR TITLE
Collapse dependencies

### DIFF
--- a/app/controllers/AbstractAuthController.scala
+++ b/app/controllers/AbstractAuthController.scala
@@ -3,38 +3,20 @@ package controllers
 import com.mohiva.play.silhouette.api.Authenticator.Implicits._
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.services.AuthenticatorResult
-import com.mohiva.play.silhouette.api.util.Clock
 import models.User
-import net.ceedubs.ficus.Ficus._
-import org.webjars.play.WebJarsUtil
-import play.api.Configuration
-import play.api.i18n.I18nSupport
 import play.api.mvc._
-import utils.auth.DefaultEnv
 
-import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * `AbstractAuthController` base with support methods to authenticate an user.
  *
- * @param silhouette The Silhouette stack.
- * @param configuration The Play configuration.
- * @param clock The clock instance.
- * @param webJarsUtil The webjar util.
- * @param assets The Play assets finder.
+ * @param scc The Silhouette stack.
  * @param ex The execution context.
  */
 abstract class AbstractAuthController(
-  silhouette: Silhouette[DefaultEnv],
-  configuration: Configuration,
-  clock: Clock
-)(
-  implicit
-  webJarsUtil: WebJarsUtil,
-  assets: AssetsFinder,
-  ex: ExecutionContext
-) extends InjectedController with I18nSupport {
+  scc: SilhouetteControllerComponents
+)(implicit ex: ExecutionContext) extends SilhouetteController(scc) {
 
   /**
    * Performs user authentication
@@ -43,21 +25,20 @@ abstract class AbstractAuthController(
    * @param request Initial request
    * @return The result to display.
    */
-  protected def authenticateUser(user: User, rememberMe: Boolean)(implicit request: Request[_]): Future[AuthenticatorResult] = {
-    val c = configuration.underlying
+  protected def authenticateUser(user: User, rememberMe: Boolean)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
     val result = Redirect(routes.ApplicationController.index())
-    silhouette.env.authenticatorService.create(user.loginInfo).map {
+    authenticatorService.create(user.loginInfo).map {
       case authenticator if rememberMe =>
         authenticator.copy(
-          expirationDateTime = clock.now + c.as[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorExpiry"),
-          idleTimeout = c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.authenticatorIdleTimeout"),
-          cookieMaxAge = c.getAs[FiniteDuration]("silhouette.authenticator.rememberMe.cookieMaxAge")
+          expirationDateTime = clock.now + scc.rememberMeConfig.expiry,
+          idleTimeout = scc.rememberMeConfig.idleTimeout,
+          cookieMaxAge = scc.rememberMeConfig.cookieMaxAge
         )
       case authenticator => authenticator
     }.flatMap { authenticator =>
-      silhouette.env.eventBus.publish(LoginEvent(user, request))
-      silhouette.env.authenticatorService.init(authenticator).flatMap { v =>
-        silhouette.env.authenticatorService.embed(v, result)
+      eventBus.publish(LoginEvent(user, request))
+      authenticatorService.init(authenticator).flatMap { v =>
+        authenticatorService.embed(v, result)
       }
     }
   }

--- a/app/controllers/ActivateAccountController.scala
+++ b/app/controllers/ActivateAccountController.scala
@@ -2,38 +2,22 @@ package controllers
 
 import java.net.URLDecoder
 import java.util.UUID
-import javax.inject.Inject
 
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
-import models.services.{ AuthTokenService, UserService }
-import play.api.i18n.{ I18nSupport, Messages }
-import play.api.libs.mailer.{ Email, MailerClient }
-import play.api.mvc.{ AbstractController, AnyContent, ControllerComponents, Request }
-import utils.auth.DefaultEnv
+import javax.inject.Inject
+import play.api.i18n.Messages
+import play.api.libs.mailer.Email
+import play.api.mvc.{ AnyContent, Request }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * The `Activate Account` controller.
- *
- * @param components       The Play controller components.
- * @param silhouette       The Silhouette stack.
- * @param userService      The user service implementation.
- * @param authTokenService The auth token service implementation.
- * @param mailerClient     The mailer client.
- * @param ex               The execution context.
  */
 class ActivateAccountController @Inject() (
-  components: ControllerComponents,
-  silhouette: Silhouette[DefaultEnv],
-  userService: UserService,
-  authTokenService: AuthTokenService,
-  mailerClient: MailerClient
-)(
-  implicit
-  ex: ExecutionContext
-) extends AbstractController(components) with I18nSupport {
+  scc: SilhouetteControllerComponents
+)(implicit ex: ExecutionContext) extends SilhouetteController(scc) {
 
   /**
    * Sends an account activation email to the user with the given email.
@@ -41,7 +25,7 @@ class ActivateAccountController @Inject() (
    * @param email The email address of the user to send the activation mail to.
    * @return The result to display.
    */
-  def send(email: String) = silhouette.UnsecuredAction.async { implicit request: Request[AnyContent] =>
+  def send(email: String) = UnsecuredAction.async { implicit request: Request[AnyContent] =>
     val decodedEmail = URLDecoder.decode(email, "UTF-8")
     val loginInfo = LoginInfo(CredentialsProvider.ID, decodedEmail)
     val result = Redirect(routes.SignInController.view()).flashing("info" -> Messages("activation.email.sent", decodedEmail))
@@ -70,7 +54,7 @@ class ActivateAccountController @Inject() (
    * @param token The token to identify a user.
    * @return The result to display.
    */
-  def activate(token: UUID) = silhouette.UnsecuredAction.async { implicit request: Request[AnyContent] =>
+  def activate(token: UUID) = UnsecuredAction.async { implicit request: Request[AnyContent] =>
     authTokenService.validate(token).flatMap {
       case Some(authToken) => userService.retrieve(authToken.userID).flatMap {
         case Some(user) if user.loginInfo.providerID == CredentialsProvider.ID =>

--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -1,51 +1,30 @@
 package controllers
 
-import javax.inject.Inject
-
 import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
 import forms.ForgotPasswordForm
-import models.services.{ AuthTokenService, UserService }
-import org.webjars.play.WebJarsUtil
-import play.api.i18n.{ I18nSupport, Messages }
-import play.api.libs.mailer.{ Email, MailerClient }
-import play.api.mvc.{ AbstractController, AnyContent, ControllerComponents, Request }
-import utils.auth.DefaultEnv
+import javax.inject.Inject
+import play.api.i18n.Messages
+import play.api.libs.mailer.Email
+import play.api.mvc.{ AnyContent, Request }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * The `Forgot Password` controller.
- *
- * @param components       The Play controller components.
- * @param silhouette       The Silhouette stack.
- * @param userService      The user service implementation.
- * @param authTokenService The auth token service implementation.
- * @param mailerClient     The mailer client.
- * @param webJarsUtil      The webjar util.
- * @param assets           The Play assets finder.
- * @param ex               The execution context.
  */
 class ForgotPasswordController @Inject() (
-  components: ControllerComponents,
-  silhouette: Silhouette[DefaultEnv],
-  userService: UserService,
-  authTokenService: AuthTokenService,
-  mailerClient: MailerClient
-)(
-  implicit
-  webJarsUtil: WebJarsUtil,
-  assets: AssetsFinder,
-  ex: ExecutionContext
-) extends AbstractController(components) with I18nSupport {
+  components: SilhouetteControllerComponents,
+  forgotPassword: views.html.forgotPassword
+)(implicit ex: ExecutionContext) extends SilhouetteController(components) {
 
   /**
    * Views the `Forgot Password` page.
    *
    * @return The result to display.
    */
-  def view = silhouette.UnsecuredAction.async { implicit request: Request[AnyContent] =>
-    Future.successful(Ok(views.html.forgotPassword(ForgotPasswordForm.form)))
+  def view = UnsecuredAction.async { implicit request: Request[AnyContent] =>
+    Future.successful(Ok(forgotPassword(ForgotPasswordForm.form)))
   }
 
   /**
@@ -56,9 +35,9 @@ class ForgotPasswordController @Inject() (
    *
    * @return The result to display.
    */
-  def submit = silhouette.UnsecuredAction.async { implicit request: Request[AnyContent] =>
+  def submit = UnsecuredAction.async { implicit request: Request[AnyContent] =>
     ForgotPasswordForm.form.bindFromRequest.fold(
-      form => Future.successful(BadRequest(views.html.forgotPassword(form))),
+      form => Future.successful(BadRequest(forgotPassword(form))),
       email => {
         val loginInfo = LoginInfo(CredentialsProvider.ID, email)
         val result = Redirect(routes.SignInController.view()).flashing("info" -> Messages("reset.email.sent"))

--- a/app/controllers/ResetPasswordController.scala
+++ b/app/controllers/ResetPasswordController.scala
@@ -1,47 +1,23 @@
 package controllers
 
 import java.util.UUID
-import javax.inject.Inject
 
-import com.mohiva.play.silhouette.api._
-import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.api.util.{ PasswordHasherRegistry, PasswordInfo }
+import com.mohiva.play.silhouette.api.util.PasswordInfo
 import com.mohiva.play.silhouette.impl.providers.CredentialsProvider
 import forms.ResetPasswordForm
-import models.services.{ AuthTokenService, UserService }
-import org.webjars.play.WebJarsUtil
-import play.api.i18n.{ I18nSupport, Messages }
-import play.api.mvc.{ AbstractController, AnyContent, ControllerComponents, Request }
-import utils.auth.DefaultEnv
+import javax.inject.Inject
+import play.api.i18n.Messages
+import play.api.mvc.{ AnyContent, Request }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * The `Reset Password` controller.
- *
- * @param components             The Play controller components.
- * @param silhouette             The Silhouette stack.
- * @param userService            The user service implementation.
- * @param authInfoRepository     The auth info repository.
- * @param passwordHasherRegistry The password hasher registry.
- * @param authTokenService       The auth token service implementation.
- * @param webJarsUtil            The webjar util.
- * @param assets                 The Play assets finder.
- * @param ex                     The execution context.
  */
 class ResetPasswordController @Inject() (
-  components: ControllerComponents,
-  silhouette: Silhouette[DefaultEnv],
-  userService: UserService,
-  authInfoRepository: AuthInfoRepository,
-  passwordHasherRegistry: PasswordHasherRegistry,
-  authTokenService: AuthTokenService
-)(
-  implicit
-  webJarsUtil: WebJarsUtil,
-  assets: AssetsFinder,
-  ex: ExecutionContext
-) extends AbstractController(components) with I18nSupport {
+  scc: SilhouetteControllerComponents,
+  resetPassword: views.html.resetPassword
+)(implicit ex: ExecutionContext) extends SilhouetteController(scc) {
 
   /**
    * Views the `Reset Password` page.
@@ -49,9 +25,9 @@ class ResetPasswordController @Inject() (
    * @param token The token to identify a user.
    * @return The result to display.
    */
-  def view(token: UUID) = silhouette.UnsecuredAction.async { implicit request: Request[AnyContent] =>
+  def view(token: UUID) = UnsecuredAction.async { implicit request: Request[AnyContent] =>
     authTokenService.validate(token).map {
-      case Some(_) => Ok(views.html.resetPassword(ResetPasswordForm.form, token))
+      case Some(_) => Ok(resetPassword(ResetPasswordForm.form, token))
       case None => Redirect(routes.SignInController.view()).flashing("error" -> Messages("invalid.reset.link"))
     }
   }
@@ -62,11 +38,11 @@ class ResetPasswordController @Inject() (
    * @param token The token to identify a user.
    * @return The result to display.
    */
-  def submit(token: UUID) = silhouette.UnsecuredAction.async { implicit request: Request[AnyContent] =>
+  def submit(token: UUID) = UnsecuredAction.async { implicit request: Request[AnyContent] =>
     authTokenService.validate(token).flatMap {
       case Some(authToken) =>
         ResetPasswordForm.form.bindFromRequest.fold(
-          form => Future.successful(BadRequest(views.html.resetPassword(form, token))),
+          form => Future.successful(BadRequest(resetPassword(form, token))),
           password => userService.retrieve(authToken.userID).flatMap {
             case Some(user) if user.loginInfo.providerID == CredentialsProvider.ID =>
               val passwordInfo = passwordHasherRegistry.current.hash(password)

--- a/app/controllers/SignInController.scala
+++ b/app/controllers/SignInController.scala
@@ -1,58 +1,33 @@
 package controllers
 
-import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.exceptions.ProviderException
-import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.api.util.{ Clock, Credentials }
+import com.mohiva.play.silhouette.api.util.Credentials
 import com.mohiva.play.silhouette.impl.exceptions.IdentityNotFoundException
 import com.mohiva.play.silhouette.impl.providers._
 import forms.{ SignInForm, TotpForm }
 import javax.inject.Inject
-import models.services.UserService
-import org.webjars.play.WebJarsUtil
-import play.api.Configuration
-import play.api.i18n.{ I18nSupport, Messages }
-import play.api.mvc.{ AnyContent, ControllerComponents, Request }
-import utils.auth.DefaultEnv
+import play.api.i18n.Messages
+import play.api.mvc.{ AnyContent, Request }
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * The `Sign In` controller.
- *
- * @param components             The Play controller components.
- * @param silhouette             The Silhouette stack.
- * @param userService            The user service implementation.
- * @param credentialsProvider    The credentials provider.
- * @param socialProviderRegistry The social provider registry.
- * @param configuration          The Play configuration.
- * @param clock                  The clock instance.
- * @param webJarsUtil            The webjar util.
- * @param assets                 The Play assets finder.
  */
 class SignInController @Inject() (
-  components: ControllerComponents,
-  silhouette: Silhouette[DefaultEnv],
-  userService: UserService,
-  authInfoRepository: AuthInfoRepository,
-  credentialsProvider: CredentialsProvider,
-  socialProviderRegistry: SocialProviderRegistry,
-  configuration: Configuration,
-  clock: Clock
-)(
-  implicit
-  webJarsUtil: WebJarsUtil,
-  assets: AssetsFinder,
-  ex: ExecutionContext
-) extends AbstractAuthController(silhouette, configuration, clock) with I18nSupport {
+  scc: SilhouetteControllerComponents,
+  signIn: views.html.signIn,
+  activateAccount: views.html.activateAccount,
+  totp: views.html.totp
+)(implicit ex: ExecutionContext) extends AbstractAuthController(scc) {
 
   /**
    * Views the `Sign In` page.
    *
    * @return The result to display.
    */
-  def view = silhouette.UnsecuredAction.async { implicit request: Request[AnyContent] =>
-    Future.successful(Ok(views.html.signIn(SignInForm.form, socialProviderRegistry)))
+  def view = UnsecuredAction.async { implicit request: Request[AnyContent] =>
+    Future.successful(Ok(signIn(SignInForm.form, socialProviderRegistry)))
   }
 
   /**
@@ -60,18 +35,18 @@ class SignInController @Inject() (
    *
    * @return The result to display.
    */
-  def submit = silhouette.UnsecuredAction.async { implicit request: Request[AnyContent] =>
+  def submit = UnsecuredAction.async { implicit request: Request[AnyContent] =>
     SignInForm.form.bindFromRequest.fold(
-      form => Future.successful(BadRequest(views.html.signIn(form, socialProviderRegistry))),
+      form => Future.successful(BadRequest(signIn(form, socialProviderRegistry))),
       data => {
         val credentials = Credentials(data.email, data.password)
         credentialsProvider.authenticate(credentials).flatMap { loginInfo =>
           userService.retrieve(loginInfo).flatMap {
             case Some(user) if !user.activated =>
-              Future.successful(Ok(views.html.activateAccount(data.email)))
+              Future.successful(Ok(activateAccount(data.email)))
             case Some(user) =>
               authInfoRepository.find[GoogleTotpInfo](user.loginInfo).flatMap {
-                case Some(totpInfo) => Future.successful(Ok(views.html.totp(TotpForm.form.fill(TotpForm.Data(
+                case Some(totpInfo) => Future.successful(Ok(totp(TotpForm.form.fill(TotpForm.Data(
                   user.userID, totpInfo.sharedKey, data.rememberMe)))))
                 case _ => authenticateUser(user, data.rememberMe)
               }

--- a/app/controllers/SilhouetteController.scala
+++ b/app/controllers/SilhouetteController.scala
@@ -1,0 +1,97 @@
+package controllers
+
+import com.mohiva.play.silhouette.api.actions.{ SecuredActionBuilder, UnsecuredActionBuilder }
+import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
+import com.mohiva.play.silhouette.api.services.{ AuthenticatorService, AvatarService }
+import com.mohiva.play.silhouette.api.util.{ Clock, PasswordHasherRegistry }
+import com.mohiva.play.silhouette.api.{ EventBus, Silhouette }
+import com.mohiva.play.silhouette.impl.providers.{ CredentialsProvider, GoogleTotpProvider, SocialProviderRegistry }
+import javax.inject.Inject
+import models.services.{ AuthTokenService, UserService }
+import play.api.Logging
+import play.api.http.FileMimeTypes
+import play.api.i18n.{ I18nSupport, Langs, MessagesApi }
+import play.api.libs.mailer.MailerClient
+import play.api.mvc._
+import utils.auth.DefaultEnv
+
+import scala.concurrent.duration.FiniteDuration
+
+abstract class SilhouetteController(override protected val controllerComponents: SilhouetteControllerComponents)
+  extends MessagesAbstractController(controllerComponents) with SilhouetteComponents with I18nSupport with Logging {
+
+  def SecuredAction: SecuredActionBuilder[EnvType, AnyContent] = controllerComponents.silhouette.SecuredAction
+  def UnsecuredAction: UnsecuredActionBuilder[EnvType, AnyContent] = controllerComponents.silhouette.UnsecuredAction
+
+  def userService: UserService = controllerComponents.userService
+  def authInfoRepository: AuthInfoRepository = controllerComponents.authInfoRepository
+  def passwordHasherRegistry: PasswordHasherRegistry = controllerComponents.passwordHasherRegistry
+  def authTokenService: AuthTokenService = controllerComponents.authTokenService
+  def mailerClient: MailerClient = controllerComponents.mailerClient
+  def rememberMeConfig: RememberMeConfig = controllerComponents.rememberMeConfig
+  def clock: Clock = controllerComponents.clock
+  def credentialsProvider: CredentialsProvider = controllerComponents.credentialsProvider
+  def socialProviderRegistry: SocialProviderRegistry = controllerComponents.socialProviderRegistry
+  def totpProvider: GoogleTotpProvider = controllerComponents.totpProvider
+  def avatarService: AvatarService = controllerComponents.avatarService
+
+  def silhouette: Silhouette[EnvType] = controllerComponents.silhouette
+  def authenticatorService: AuthenticatorService[AuthType] = silhouette.env.authenticatorService
+  def eventBus: EventBus = silhouette.env.eventBus
+}
+
+trait SilhouetteComponents {
+  type EnvType = DefaultEnv
+  type AuthType = EnvType#A
+  type IdentityType = EnvType#I
+
+  def userService: UserService
+  def authInfoRepository: AuthInfoRepository
+  def passwordHasherRegistry: PasswordHasherRegistry
+  def authTokenService: AuthTokenService
+  def mailerClient: MailerClient
+  def rememberMeConfig: RememberMeConfig
+  def clock: Clock
+  def credentialsProvider: CredentialsProvider
+  def socialProviderRegistry: SocialProviderRegistry
+  def totpProvider: GoogleTotpProvider
+  def avatarService: AvatarService
+
+  def silhouette: Silhouette[EnvType]
+}
+
+trait SilhouetteControllerComponents extends MessagesControllerComponents with SilhouetteComponents
+
+final case class DefaultSilhouetteControllerComponents @Inject() (
+  silhouette: Silhouette[DefaultEnv],
+  userService: UserService,
+  authInfoRepository: AuthInfoRepository,
+  passwordHasherRegistry: PasswordHasherRegistry,
+  authTokenService: AuthTokenService,
+  mailerClient: MailerClient,
+  rememberMeConfig: RememberMeConfig,
+  clock: Clock,
+  credentialsProvider: CredentialsProvider,
+  socialProviderRegistry: SocialProviderRegistry,
+  totpProvider: GoogleTotpProvider,
+  avatarService: AvatarService,
+  messagesActionBuilder: MessagesActionBuilder,
+  actionBuilder: DefaultActionBuilder,
+  parsers: PlayBodyParsers,
+  messagesApi: MessagesApi,
+  langs: Langs,
+  fileMimeTypes: FileMimeTypes,
+  executionContext: scala.concurrent.ExecutionContext
+) extends SilhouetteControllerComponents
+
+trait RememberMeConfig {
+  def expiry: FiniteDuration
+  def idleTimeout: Option[FiniteDuration]
+  def cookieMaxAge: Option[FiniteDuration]
+}
+
+final case class DefaultRememberMeConfig(
+  expiry: FiniteDuration,
+  idleTimeout: Option[FiniteDuration],
+  cookieMaxAge: Option[FiniteDuration])
+  extends RememberMeConfig

--- a/app/controllers/TotpRecoveryController.scala
+++ b/app/controllers/TotpRecoveryController.scala
@@ -2,48 +2,22 @@ package controllers
 
 import java.util.UUID
 
-import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.exceptions.ProviderException
-import com.mohiva.play.silhouette.api.repositories.AuthInfoRepository
-import com.mohiva.play.silhouette.api.util.Clock
 import com.mohiva.play.silhouette.impl.exceptions.IdentityNotFoundException
 import com.mohiva.play.silhouette.impl.providers._
 import forms.TotpRecoveryForm
 import javax.inject.Inject
-import models.services.UserService
-import org.webjars.play.WebJarsUtil
-import play.api.Configuration
-import play.api.i18n.{ I18nSupport, Messages }
-import utils.auth.DefaultEnv
+import play.api.i18n.Messages
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 /**
  * The `TOTP` controller.
- *
- * @param silhouette The Silhouette stack.
- * @param userService The user service implementation.
- * @param totpProvider The totp provider.
- * @param configuration The Play configuration.
- * @param clock The clock instance.
- * @param webJarsUtil The webjar util.
- * @param assets The Play assets finder.
- * @param ex The execution context.
- * @param authInfoRepository The auth info repository.
  */
 class TotpRecoveryController @Inject() (
-  silhouette: Silhouette[DefaultEnv],
-  userService: UserService,
-  totpProvider: GoogleTotpProvider,
-  configuration: Configuration,
-  clock: Clock
-)(
-  implicit
-  webJarsUtil: WebJarsUtil,
-  assets: AssetsFinder,
-  ex: ExecutionContext,
-  authInfoRepository: AuthInfoRepository
-) extends AbstractAuthController(silhouette, configuration, clock) with I18nSupport {
+  scc: SilhouetteControllerComponents,
+  totpRecovery: views.html.totpRecovery
+)(implicit ex: ExecutionContext) extends AbstractAuthController(scc) {
 
   /**
    * Views the TOTP recovery page.
@@ -53,17 +27,17 @@ class TotpRecoveryController @Inject() (
    * @param rememberMe the remember me flag.
    * @return The result to display.
    */
-  def view(userID: UUID, sharedKey: String, rememberMe: Boolean) = silhouette.UnsecuredAction.async { implicit request =>
-    Future.successful(Ok(views.html.totpRecovery(TotpRecoveryForm.form.fill(TotpRecoveryForm.Data(userID, sharedKey, rememberMe)))))
+  def view(userID: UUID, sharedKey: String, rememberMe: Boolean) = UnsecuredAction.async { implicit request =>
+    Future.successful(Ok(totpRecovery(TotpRecoveryForm.form.fill(TotpRecoveryForm.Data(userID, sharedKey, rememberMe)))))
   }
 
   /**
    * Handles the submitted form with TOTP verification key.
    * @return The result to display.
    */
-  def submit = silhouette.UnsecuredAction.async { implicit request =>
+  def submit = UnsecuredAction.async { implicit request =>
     TotpRecoveryForm.form.bindFromRequest.fold(
-      form => Future.successful(BadRequest(views.html.totpRecovery(form))),
+      form => Future.successful(BadRequest(totpRecovery(form))),
       data => {
         val totpRecoveryControllerRoute = routes.TotpRecoveryController.view(data.userID, data.sharedKey, data.rememberMe)
         userService.retrieve(data.userID).flatMap {

--- a/app/views/activateAccount.scala.html
+++ b/app/views/activateAccount.scala.html
@@ -4,7 +4,8 @@
 @import org.webjars.play.WebJarsUtil
 @import controllers.AssetsFinder
 
-@(email: String)(implicit request: RequestHeader, messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(email: String)(implicit request: RequestHeader, messages: Messages)
 
 @main(messages("activate.account.title")) {
     <fieldset class="col-md-6 col-md-offset-3">

--- a/app/views/changePassword.scala.html
+++ b/app/views/changePassword.scala.html
@@ -5,7 +5,8 @@
 @import controllers.AssetsFinder
 @import b3.inline.fieldConstructor
 
-@(changePasswordForm: Form[(String, String)], user: models.User)(implicit request: RequestHeader, messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(changePasswordForm: Form[(String, String)], user: models.User)(implicit request: RequestHeader, messages: Messages)
 
 @implicitFieldConstructor = @{ b3.vertical.fieldConstructor() }
 

--- a/app/views/forgotPassword.scala.html
+++ b/app/views/forgotPassword.scala.html
@@ -4,7 +4,8 @@
 @import org.webjars.play.WebJarsUtil
 @import controllers.AssetsFinder
 
-@(forgotPasswordForm: Form[String])(implicit request: RequestHeader, messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(forgotPasswordForm: Form[String])(implicit request: RequestHeader, messages: Messages)
 
 @implicitFieldConstructor = @{ b3.vertical.fieldConstructor() }
 

--- a/app/views/home.scala.html
+++ b/app/views/home.scala.html
@@ -7,8 +7,8 @@
 @import com.mohiva.play.silhouette.impl.providers.GoogleTotpCredentials
 @import com.mohiva.play.silhouette.impl.providers.GoogleTotpInfo
 
-@(user: models.User, totpInfoOpt: Option[GoogleTotpInfo], totpDataOpt: Option[(Form[Data], GoogleTotpCredentials)] = None)(implicit request: RequestHeader,
-        messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(user: models.User, totpInfoOpt: Option[GoogleTotpInfo], totpDataOpt: Option[(Form[Data], GoogleTotpCredentials)] = None)(implicit request: RequestHeader, messages: Messages)
 
 @implicitFieldConstructor = @{
     b3.vertical.fieldConstructor()

--- a/app/views/resetPassword.scala.html
+++ b/app/views/resetPassword.scala.html
@@ -5,7 +5,8 @@
 @import controllers.AssetsFinder
 @import java.util.UUID
 
-@(form: Form[String], token: UUID)(implicit request: RequestHeader, messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(form: Form[String], token: UUID)(implicit request: RequestHeader, messages: Messages)
 
 @main(messages("reset.password.title")) {
     <fieldset class="col-md-6 col-md-offset-3">

--- a/app/views/signIn.scala.html
+++ b/app/views/signIn.scala.html
@@ -6,7 +6,8 @@
 @import com.mohiva.play.silhouette.impl.providers.SocialProviderRegistry
 @import forms.SignInForm.Data
 
-@(signInForm: Form[Data], socialProviders: SocialProviderRegistry)(implicit request: RequestHeader, messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(signInForm: Form[Data], socialProviders: SocialProviderRegistry)(implicit request: RequestHeader, messages: Messages)
 
 @implicitFieldConstructor = @{ b3.vertical.fieldConstructor() }
 

--- a/app/views/signUp.scala.html
+++ b/app/views/signUp.scala.html
@@ -5,7 +5,8 @@
 @import controllers.AssetsFinder
 @import forms.SignUpForm.Data
 
-@(signUpForm: Form[Data])(implicit request: RequestHeader, messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(signUpForm: Form[Data])(implicit request: RequestHeader, messages: Messages)
 
 @implicitFieldConstructor = @{ b3.vertical.fieldConstructor() }
 

--- a/app/views/totp.scala.html
+++ b/app/views/totp.scala.html
@@ -7,7 +7,8 @@
 @import forms.TotpRecoveryForm
 @import java.util.UUID
 
-@(totpForm: Form[Data])(implicit request: RequestHeader, messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(totpForm: Form[Data])(implicit request: RequestHeader, messages: Messages)
 
 @implicitFieldConstructor = @{ b3.vertical.fieldConstructor() }
 

--- a/app/views/totpRecovery.scala.html
+++ b/app/views/totpRecovery.scala.html
@@ -5,7 +5,8 @@
 @import controllers.AssetsFinder
 @import forms.TotpRecoveryForm.Data
 
-@(totpRecoveryForm: Form[Data])(implicit request: RequestHeader, messages: Messages, webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@this()(implicit webJarsUtil: WebJarsUtil, assets: AssetsFinder)
+@(totpRecoveryForm: Form[Data])(implicit request: RequestHeader, messages: Messages)
 
     @implicitFieldConstructor = @{
         b3.vertical.fieldConstructor()


### PR DESCRIPTION
## Purpose

This PR collapses the injected dependencies in the controllers and centralizes them in a `SilhouetteControllerComponents` trait which is then exposed as methods in a `SilhouetteController`.

Twirl templates are likewise injected so that twirl-specific code like `AssetsFinder` and `WebjarUtils` are passed in automatically.

There's also some type aliases in the trait to help out the compiler, and the "rememberme" config has been broken out into a case class.

## Background Context

Controller components are infrastructure, and so whenever you're using silhouette specific functionality you want everything to be there.  This approach makes extending controller functionality much easier and focuses attention on the implementation.