### PR TITLE
Centralize calls in one place

### DIFF
--- a/app/controllers/AbstractAuthController.scala
+++ b/app/controllers/AbstractAuthController.scala
@@ -5,6 +5,7 @@ import com.mohiva.play.silhouette.api._
 import com.mohiva.play.silhouette.api.services.AuthenticatorResult
 import models.User
 import play.api.mvc._
+import utils.route.Calls
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -26,7 +27,7 @@ abstract class AbstractAuthController(
    * @return The result to display.
    */
   protected def authenticateUser(user: User, rememberMe: Boolean)(implicit request: RequestHeader): Future[AuthenticatorResult] = {
-    val result = Redirect(routes.ApplicationController.index())
+    val result = Redirect(Calls.home)
     authenticatorService.create(user.loginInfo).map {
       case authenticator if rememberMe =>
         authenticator.copy(

--- a/app/controllers/ActivateAccountController.scala
+++ b/app/controllers/ActivateAccountController.scala
@@ -9,6 +9,7 @@ import javax.inject.Inject
 import play.api.i18n.Messages
 import play.api.libs.mailer.Email
 import play.api.mvc.{ AnyContent, Request }
+import utils.route.Calls
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -28,7 +29,7 @@ class ActivateAccountController @Inject() (
   def send(email: String) = UnsecuredAction.async { implicit request: Request[AnyContent] =>
     val decodedEmail = URLDecoder.decode(email, "UTF-8")
     val loginInfo = LoginInfo(CredentialsProvider.ID, decodedEmail)
-    val result = Redirect(routes.SignInController.view()).flashing("info" -> Messages("activation.email.sent", decodedEmail))
+    val result = Redirect(Calls.signin).flashing("info" -> Messages("activation.email.sent", decodedEmail))
 
     userService.retrieve(loginInfo).flatMap {
       case Some(user) if !user.activated =>
@@ -59,11 +60,11 @@ class ActivateAccountController @Inject() (
       case Some(authToken) => userService.retrieve(authToken.userID).flatMap {
         case Some(user) if user.loginInfo.providerID == CredentialsProvider.ID =>
           userService.save(user.copy(activated = true)).map { _ =>
-            Redirect(routes.SignInController.view()).flashing("success" -> Messages("account.activated"))
+            Redirect(Calls.signin).flashing("success" -> Messages("account.activated"))
           }
-        case _ => Future.successful(Redirect(routes.SignInController.view()).flashing("error" -> Messages("invalid.activation.link")))
+        case _ => Future.successful(Redirect(Calls.signin).flashing("error" -> Messages("invalid.activation.link")))
       }
-      case None => Future.successful(Redirect(routes.SignInController.view()).flashing("error" -> Messages("invalid.activation.link")))
+      case None => Future.successful(Redirect(Calls.signin).flashing("error" -> Messages("invalid.activation.link")))
     }
   }
 }

--- a/app/controllers/ApplicationController.scala
+++ b/app/controllers/ApplicationController.scala
@@ -5,6 +5,7 @@ import com.mohiva.play.silhouette.api.actions._
 import com.mohiva.play.silhouette.impl.providers.GoogleTotpInfo
 import javax.inject.Inject
 import play.api.mvc._
+import utils.route.Calls
 
 import scala.concurrent.ExecutionContext
 
@@ -33,7 +34,7 @@ class ApplicationController @Inject() (
    * @return The result to display.
    */
   def signOut = SecuredAction.async { implicit request: SecuredRequest[EnvType, AnyContent] =>
-    val result = Redirect(routes.ApplicationController.index())
+    val result = Redirect(Calls.home)
     eventBus.publish(LogoutEvent(request.identity, request))
     authenticatorService.discard(request.authenticator, result)
   }

--- a/app/controllers/ForgotPasswordController.scala
+++ b/app/controllers/ForgotPasswordController.scala
@@ -7,6 +7,7 @@ import javax.inject.Inject
 import play.api.i18n.Messages
 import play.api.libs.mailer.Email
 import play.api.mvc.{ AnyContent, Request }
+import utils.route.Calls
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -40,7 +41,7 @@ class ForgotPasswordController @Inject() (
       form => Future.successful(BadRequest(forgotPassword(form))),
       email => {
         val loginInfo = LoginInfo(CredentialsProvider.ID, email)
-        val result = Redirect(routes.SignInController.view()).flashing("info" -> Messages("reset.email.sent"))
+        val result = Redirect(Calls.signin).flashing("info" -> Messages("reset.email.sent"))
         userService.retrieve(loginInfo).flatMap {
           case Some(user) if user.email.isDefined =>
             authTokenService.create(user.userID).map { authToken =>

--- a/app/controllers/ResetPasswordController.scala
+++ b/app/controllers/ResetPasswordController.scala
@@ -8,6 +8,7 @@ import forms.ResetPasswordForm
 import javax.inject.Inject
 import play.api.i18n.Messages
 import play.api.mvc.{ AnyContent, Request }
+import utils.route.Calls
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -28,7 +29,7 @@ class ResetPasswordController @Inject() (
   def view(token: UUID) = UnsecuredAction.async { implicit request: Request[AnyContent] =>
     authTokenService.validate(token).map {
       case Some(_) => Ok(resetPassword(ResetPasswordForm.form, token))
-      case None => Redirect(routes.SignInController.view()).flashing("error" -> Messages("invalid.reset.link"))
+      case None => Redirect(Calls.signin).flashing("error" -> Messages("invalid.reset.link"))
     }
   }
 
@@ -47,12 +48,12 @@ class ResetPasswordController @Inject() (
             case Some(user) if user.loginInfo.providerID == CredentialsProvider.ID =>
               val passwordInfo = passwordHasherRegistry.current.hash(password)
               authInfoRepository.update[PasswordInfo](user.loginInfo, passwordInfo).map { _ =>
-                Redirect(routes.SignInController.view()).flashing("success" -> Messages("password.reset"))
+                Redirect(Calls.signin).flashing("success" -> Messages("password.reset"))
               }
-            case _ => Future.successful(Redirect(routes.SignInController.view()).flashing("error" -> Messages("invalid.reset.link")))
+            case _ => Future.successful(Redirect(Calls.signin).flashing("error" -> Messages("invalid.reset.link")))
           }
         )
-      case None => Future.successful(Redirect(routes.SignInController.view()).flashing("error" -> Messages("invalid.reset.link")))
+      case None => Future.successful(Redirect(Calls.signin).flashing("error" -> Messages("invalid.reset.link")))
     }
   }
 }

--- a/app/controllers/SignInController.scala
+++ b/app/controllers/SignInController.scala
@@ -8,6 +8,7 @@ import forms.{ SignInForm, TotpForm }
 import javax.inject.Inject
 import play.api.i18n.Messages
 import play.api.mvc.{ AnyContent, Request }
+import utils.route.Calls
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -54,7 +55,7 @@ class SignInController @Inject() (
           }
         }.recover {
           case _: ProviderException =>
-            Redirect(routes.SignInController.view()).flashing("error" -> Messages("invalid.credentials"))
+            Redirect(Calls.signin).flashing("error" -> Messages("invalid.credentials"))
         }
       }
     )

--- a/app/controllers/SignUpController.scala
+++ b/app/controllers/SignUpController.scala
@@ -10,6 +10,7 @@ import models.User
 import play.api.i18n.Messages
 import play.api.libs.mailer.Email
 import play.api.mvc.{ AnyContent, Request }
+import utils.route.Calls
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -43,7 +44,7 @@ class SignUpController @Inject() (
         val loginInfo = LoginInfo(CredentialsProvider.ID, data.email)
         userService.retrieve(loginInfo).flatMap {
           case Some(user) =>
-            val url = routes.SignInController.view().absoluteURL()
+            val url = Calls.signin.absoluteURL()
             mailerClient.send(Email(
               subject = Messages("email.already.signed.up.subject"),
               from = Messages("email.from"),

--- a/app/controllers/SocialAuthController.scala
+++ b/app/controllers/SocialAuthController.scala
@@ -6,6 +6,7 @@ import com.mohiva.play.silhouette.impl.providers._
 import javax.inject.Inject
 import play.api.i18n.Messages
 import play.api.mvc.{ AnyContent, Request }
+import utils.route.Calls
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -43,7 +44,7 @@ class SocialAuthController @Inject() (
     }).recover {
       case e: ProviderException =>
         logger.error("Unexpected provider error", e)
-        Redirect(routes.SignInController.view()).flashing("error" -> Messages("could.not.authenticate"))
+        Redirect(Calls.signin).flashing("error" -> Messages("could.not.authenticate"))
     }
   }
 }

--- a/app/controllers/TotpController.scala
+++ b/app/controllers/TotpController.scala
@@ -7,6 +7,7 @@ import com.mohiva.play.silhouette.impl.providers._
 import forms.{ TotpForm, TotpSetupForm }
 import javax.inject.Inject
 import play.api.i18n.Messages
+import utils.route.Calls
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -48,7 +49,7 @@ class TotpController @Inject() (
   def disableTotp = SecuredAction.async { implicit request =>
     val user = request.identity
     authInfoRepository.remove[GoogleTotpInfo](user.loginInfo)
-    Future(Redirect(routes.ApplicationController.index()).flashing("info" -> Messages("totp.disabling.info")))
+    Future(Redirect(Calls.home).flashing("info" -> Messages("totp.disabling.info")))
   }
 
   /**
@@ -65,9 +66,9 @@ class TotpController @Inject() (
         totpProvider.authenticate(data.sharedKey, data.verificationCode).flatMap {
           case Some(loginInfo: LoginInfo) => {
             authInfoRepository.add[GoogleTotpInfo](user.loginInfo, GoogleTotpInfo(data.sharedKey, data.scratchCodes))
-            Future(Redirect(routes.ApplicationController.index()).flashing("success" -> Messages("totp.enabling.info")))
+            Future(Redirect(Calls.home).flashing("success" -> Messages("totp.enabling.info")))
           }
-          case _ => Future.successful(Redirect(routes.ApplicationController.index()).flashing("error" -> Messages("invalid.verification.code")))
+          case _ => Future.successful(Redirect(Calls.home).flashing("error" -> Messages("invalid.verification.code")))
         }.recover {
           case _: ProviderException =>
             Redirect(routes.TotpController.view(user.userID, data.sharedKey, request.authenticator.cookieMaxAge.isDefined)).flashing("error" -> Messages("invalid.unexpected.totp"))

--- a/app/utils/auth/CustomSecuredErrorHandler.scala
+++ b/app/utils/auth/CustomSecuredErrorHandler.scala
@@ -1,11 +1,11 @@
 package utils.auth
 
 import javax.inject.Inject
-
 import com.mohiva.play.silhouette.api.actions.SecuredErrorHandler
-import play.api.i18n.{ MessagesApi, I18nSupport, Messages }
-import play.api.mvc.RequestHeader
+import play.api.i18n.{ I18nSupport, Messages, MessagesApi }
+import play.api.mvc.{ Call, RequestHeader }
 import play.api.mvc.Results._
+import utils.route.Calls
 
 import scala.concurrent.Future
 
@@ -25,7 +25,7 @@ class CustomSecuredErrorHandler @Inject() (val messagesApi: MessagesApi) extends
    * @return The result to send to the client.
    */
   override def onNotAuthenticated(implicit request: RequestHeader) = {
-    Future.successful(Redirect(controllers.routes.SignInController.view()))
+    Future.successful(Redirect(Calls.signin))
   }
 
   /**
@@ -37,6 +37,6 @@ class CustomSecuredErrorHandler @Inject() (val messagesApi: MessagesApi) extends
    * @return The result to send to the client.
    */
   override def onNotAuthorized(implicit request: RequestHeader) = {
-    Future.successful(Redirect(controllers.routes.SignInController.view()).flashing("error" -> Messages("access.denied")))
+    Future.successful(Redirect(Calls.signin).flashing("error" -> Messages("access.denied")))
   }
 }

--- a/app/utils/auth/CustomUnsecuredErrorHandler.scala
+++ b/app/utils/auth/CustomUnsecuredErrorHandler.scala
@@ -3,6 +3,7 @@ package utils.auth
 import com.mohiva.play.silhouette.api.actions.UnsecuredErrorHandler
 import play.api.mvc.RequestHeader
 import play.api.mvc.Results._
+import utils.route.Calls
 
 import scala.concurrent.Future
 
@@ -20,6 +21,6 @@ class CustomUnsecuredErrorHandler extends UnsecuredErrorHandler {
    * @return The result to send to the client.
    */
   override def onNotAuthorized(implicit request: RequestHeader) = {
-    Future.successful(Redirect(controllers.routes.ApplicationController.index()))
+    Future.successful(Redirect(Calls.home))
   }
 }

--- a/app/utils/route/Calls.scala
+++ b/app/utils/route/Calls.scala
@@ -1,0 +1,14 @@
+package utils.route
+
+import play.api.mvc.Call
+
+/**
+ * Defines some common redirect calls used in authentication flow.
+ */
+object Calls {
+  /** @return The URL to redirect to when an authentication succeeds. */
+  def home: Call = controllers.routes.ApplicationController.index()
+
+  /** @return The URL to redirect to when an authentication fails. */
+  def signin: Call = controllers.routes.SignInController.view()
+}


### PR DESCRIPTION
## Purpose

Centralizes "success" and "failure" redirect calls in one place.

## Background Context

The seed is mostly self contained in routes, but all parts of the application rely on the routes, and if the controllers are renamed then each call must also be replaced in every file.  This PR ensures that a route call only happens in one place.

## References

Are there any relevant issues / PRs / mailing lists discussions?