### PR TITLE
Add heroku to allowed hosts

### DIFF
--- a/conf/application.prod.conf
+++ b/conf/application.prod.conf
@@ -51,3 +51,8 @@ silhouette {
   yahoo.callbackURL="https://play-silhouette-seed.herokuapp.com/authenticate/yahoo"
   yahoo.realm="https://play-silhouette-seed.herokuapp.com"
 }
+
+play.filters.hosts {
+  # Allow requests to heroku, its subdomains, and localhost:9000.
+  allowed = [".herokuapp.com", "localhost:9000"]
+}


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)?
* [x] Have you read through the [contributor guidelines](https://github.com/mohiva/play-silhouette-seed/blob/master/CONTRIBUTING.md)?

## Fixes

setting heroku as an allowed host so the Deploy to Heroku button deploys an app that doesn't immediately error.

## Purpose

A more seamless flow for those who want to explore this app on Heroku

## Background Context

At first I cloned this repo and used `heroku create` to host my own app for exploring the project. But Heroku always moves the app to a crashed state and I never get a request through. I used the Deploy to Heroku button and got further. That button results in a Play error page that the host is not allowed. Updating this config file allows the play app to run as one would expect.

This is my first PR here, please let me know if I am missing anything.
